### PR TITLE
Add secure travel plan viewer prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
-# Every City Plan – Secure plan viewer
+# Every City Plan – Login screen
 
-A simple static prototype for the Every City Plan website. Travelers sign in to a secure viewer to browse time-limited city itineraries without downloading or printing them.
+A focused login page prototype for the Every City Plan website. Collects a user's email and password with a modern, secure-first design.
 
 ## Features
-- **Login gate** with demo credentials (`traveler@everycityplan.com` / `demo123`).
-- **Secure viewing controls**: watermarking, disabled copy/print shortcuts, and blocked context menu.
-- **Timed sessions**: automatic expiration with a one-click reactivation button.
-- **City selector** for New York, Paris, and Tokyo sample plans.
+- **Member login form** with required email and password inputs.
+- **Password visibility toggle** to quickly check entries without retyping.
+- **Demo credentials** for previewing the flow: `traveler@everycityplan.com` / `demo123`.
+- **Inline validation messaging** for success and error states.
 
 ## Usage
 1. Open `index.html` in a browser.
-2. Sign in with the demo credentials above (or any non-empty email/password for exploration).
-3. Browse the plan; note that downloads, copy shortcuts, and printing are blocked and the session counts down.
+2. Enter your account email and password, or use the demo credentials above.
+3. Submit to see inline feedback for a successful or failed login attempt.
 
 ## Notes
-- The anti-download and anti-screenshot measures are deterrents; no web app can fully prevent screen capture.
-- Extend the `plans` object in `script.js` to add real itineraries and city-specific tips.
+- The "Forgot password" link is disabled in this prototype and can be wired to recovery flows later.
+- Replace the demo validation in `script.js` with your real authentication call when integrating.

--- a/README.md
+++ b/README.md
@@ -1,16 +1,18 @@
-## Hi there 👋
+# Every City Plan – Secure plan viewer
 
-<!--
-**Everycityplan/Everycityplan** is a ✨ _special_ ✨ repository because its `README.md` (this file) appears on your GitHub profile.
+A simple static prototype for the Every City Plan website. Travelers sign in to a secure viewer to browse time-limited city itineraries without downloading or printing them.
 
-Here are some ideas to get you started:
+## Features
+- **Login gate** with demo credentials (`traveler@everycityplan.com` / `demo123`).
+- **Secure viewing controls**: watermarking, disabled copy/print shortcuts, and blocked context menu.
+- **Timed sessions**: automatic expiration with a one-click reactivation button.
+- **City selector** for New York, Paris, and Tokyo sample plans.
 
-- 🔭 I’m currently working on ...
-- 🌱 I’m currently learning ...
-- 👯 I’m looking to collaborate on ...
-- 🤔 I’m looking for help with ...
-- 💬 Ask me about ...
-- 📫 How to reach me: ...
-- 😄 Pronouns: ...
-- ⚡ Fun fact: ...
--->
+## Usage
+1. Open `index.html` in a browser.
+2. Sign in with the demo credentials above (or any non-empty email/password for exploration).
+3. Browse the plan; note that downloads, copy shortcuts, and printing are blocked and the session counts down.
+
+## Notes
+- The anti-download and anti-screenshot measures are deterrents; no web app can fully prevent screen capture.
+- Extend the `plans` object in `script.js` to add real itineraries and city-specific tips.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Every City Plan | Secure Viewer</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="hero">
+    <div class="hero__content">
+      <p class="eyebrow">Every City Plan</p>
+      <h1>Sell and showcase travel plans with a secure, time-boxed viewer.</h1>
+      <p class="lede">
+        Welcome to the Every City Plan secure portal. Travelers can log in to view personalized city plans without downloads,
+        printing, or easy screenshots, while you keep control of your premium itineraries.
+      </p>
+    </div>
+    <div class="hero__cta">
+      <div class="card" id="login-card">
+        <h2>Member sign-in</h2>
+        <p class="muted">Use your email and password to open your plan.</p>
+        <form id="login-form" class="form">
+          <label class="form__label" for="email">Email</label>
+          <input class="form__input" id="email" name="email" type="email" autocomplete="username" required />
+          <label class="form__label" for="password">Password</label>
+          <input class="form__input" id="password" name="password" type="password" autocomplete="current-password" required />
+          <button class="button" type="submit">Access my plan</button>
+          <p class="helper">Tip: use <strong>traveler@everycityplan.com</strong> / <strong>demo123</strong> to try it.</p>
+        </form>
+        <p class="status" id="status" role="status"></p>
+      </div>
+    </div>
+  </header>
+
+  <main class="layout">
+    <section class="card" id="viewer" aria-live="polite" hidden>
+      <div class="viewer__header">
+        <div>
+          <p class="eyebrow" id="welcome"></p>
+          <h2 id="city-title">Your secure plan</h2>
+          <p class="muted" id="session-timer">Session time: --:-- remaining</p>
+        </div>
+        <div class="controls">
+          <label class="form__label" for="city-select">Change city</label>
+          <select id="city-select" class="form__input form__input--select"></select>
+          <button class="button button--ghost" id="restart-session" type="button">Restart timer</button>
+        </div>
+      </div>
+
+      <div class="viewer__body">
+        <aside class="panel">
+          <h3>Plan navigation</h3>
+          <ul class="nav" id="day-nav"></ul>
+          <div class="callout">
+            <p class="callout__title">Capture-safe design</p>
+            <ul class="callout__list">
+              <li>Watermarked with the signed-in email</li>
+              <li>Download, printing, and selection disabled</li>
+              <li>Session expires automatically</li>
+            </ul>
+          </div>
+        </aside>
+        <article class="plan" id="plan">
+          <div class="watermark" id="watermark" aria-hidden="true"></div>
+          <div class="plan__content" id="plan-content"></div>
+          <div class="overlay" id="overlay" hidden>
+            <p>Your secure viewing session has ended. Restart the timer to continue.</p>
+            <button class="button" id="reactivate" type="button">Reactivate viewer</button>
+          </div>
+        </article>
+      </div>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <p>Need a bespoke travel plan? Email <a href="mailto:hello@everycityplan.com">hello@everycityplan.com</a>.</p>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -3,78 +3,56 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Every City Plan | Secure Viewer</title>
+  <title>Every City Plan | Sign in</title>
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-  <header class="hero">
-    <div class="hero__content">
+  <main class="page">
+    <section class="intro">
       <p class="eyebrow">Every City Plan</p>
-      <h1>Sell and showcase travel plans with a secure, time-boxed viewer.</h1>
-      <p class="lede">
-        Welcome to the Every City Plan secure portal. Travelers can log in to view personalized city plans without downloads,
-        printing, or easy screenshots, while you keep control of your premium itineraries.
-      </p>
-    </div>
-    <div class="hero__cta">
-      <div class="card" id="login-card">
-        <h2>Member sign-in</h2>
-        <p class="muted">Use your email and password to open your plan.</p>
-        <form id="login-form" class="form">
-          <label class="form__label" for="email">Email</label>
-          <input class="form__input" id="email" name="email" type="email" autocomplete="username" required />
-          <label class="form__label" for="password">Password</label>
-          <input class="form__input" id="password" name="password" type="password" autocomplete="current-password" required />
-          <button class="button" type="submit">Access my plan</button>
-          <p class="helper">Tip: use <strong>traveler@everycityplan.com</strong> / <strong>demo123</strong> to try it.</p>
-        </form>
-        <p class="status" id="status" role="status"></p>
-      </div>
-    </div>
-  </header>
+      <h1>Sign in to view your travel plans</h1>
+      <p class="lede">Access your purchased city plan with your account email and password. Your content stays protected while you browse.</p>
+      <ul class="bullets">
+        <li>Secure, time-boxed viewing of your itinerary</li>
+        <li>No downloads or printing to keep plans exclusive</li>
+        <li>Personalized recommendations for any city</li>
+      </ul>
+    </section>
 
-  <main class="layout">
-    <section class="card" id="viewer" aria-live="polite" hidden>
-      <div class="viewer__header">
-        <div>
-          <p class="eyebrow" id="welcome"></p>
-          <h2 id="city-title">Your secure plan</h2>
-          <p class="muted" id="session-timer">Session time: --:-- remaining</p>
-        </div>
-        <div class="controls">
-          <label class="form__label" for="city-select">Change city</label>
-          <select id="city-select" class="form__input form__input--select"></select>
-          <button class="button button--ghost" id="restart-session" type="button">Restart timer</button>
-        </div>
+    <section class="panel">
+      <div class="panel__header">
+        <h2>Member login</h2>
+        <p class="muted">Enter your credentials to continue.</p>
       </div>
+      <form id="login-form" class="form" novalidate>
+        <label class="form__label" for="email">Email</label>
+        <input class="form__input" id="email" name="email" type="email" autocomplete="username" required />
 
-      <div class="viewer__body">
-        <aside class="panel">
-          <h3>Plan navigation</h3>
-          <ul class="nav" id="day-nav"></ul>
-          <div class="callout">
-            <p class="callout__title">Capture-safe design</p>
-            <ul class="callout__list">
-              <li>Watermarked with the signed-in email</li>
-              <li>Download, printing, and selection disabled</li>
-              <li>Session expires automatically</li>
-            </ul>
+        <div class="form__row">
+          <div class="form__field">
+            <label class="form__label" for="password">Password</label>
+            <input class="form__input" id="password" name="password" type="password" autocomplete="current-password" required />
           </div>
-        </aside>
-        <article class="plan" id="plan">
-          <div class="watermark" id="watermark" aria-hidden="true"></div>
-          <div class="plan__content" id="plan-content"></div>
-          <div class="overlay" id="overlay" hidden>
-            <p>Your secure viewing session has ended. Restart the timer to continue.</p>
-            <button class="button" id="reactivate" type="button">Reactivate viewer</button>
-          </div>
-        </article>
-      </div>
+          <button class="button button--ghost" id="toggle-password" type="button" aria-pressed="false">Show</button>
+        </div>
+
+        <div class="form__row form__row--between">
+          <label class="checkbox">
+            <input type="checkbox" id="remember" name="remember" />
+            <span>Remember me on this device</span>
+          </label>
+          <a class="link" href="#" aria-disabled="true">Forgot password?</a>
+        </div>
+
+        <button class="button" type="submit">Log in</button>
+        <p class="helper">Demo access: <strong>traveler@everycityplan.com</strong> / <strong>demo123</strong></p>
+        <p class="status" id="status" role="status" aria-live="polite"></p>
+      </form>
     </section>
   </main>
 
   <footer class="footer">
-    <p>Need a bespoke travel plan? Email <a href="mailto:hello@everycityplan.com">hello@everycityplan.com</a>.</p>
+    <p>Need help? Email <a href="mailto:hello@everycityplan.com">hello@everycityplan.com</a>.</p>
   </footer>
 
   <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -1,262 +1,53 @@
-const demoUser = {
+const demoCredentials = {
   email: "traveler@everycityplan.com",
   password: "demo123",
 };
 
-const plans = {
-  "New York": {
-    intro: "48 hours of architecture, skyline views, and local eats.",
-    days: [
-      {
-        title: "Day 1 – Midtown Icons",
-        badge: "Skylines",
-        stops: [
-          "Sunrise at Top of the Rock; book timed entry.",
-          "Walk Fifth Avenue to Bryant Park espresso stop.",
-          "Lunch at Urbanspace food hall; rotate cuisines.",
-          "Grand Central whispering gallery and market pick-up.",
-          "Evening show in Broadway's Theater District.",
-        ],
-      },
-      {
-        title: "Day 2 – Downtown Art & Waterfront",
-        badge: "Culture",
-        stops: [
-          "SoHo galleries before 11am for quiet viewing.",
-          "9/11 Memorial; reserve museum ahead.",
-          "Oculus + Brookfield Place for design and dining.",
-          "Sunset walk on the Brooklyn Bridge ending in DUMBO pizza.",
-        ],
-      },
-    ],
-    notes: [
-      "Use the 7-day MetroCard for unlimited subway rides.",
-      "Book observation decks 2 weeks out for best slots.",
-    ],
-  },
-  Paris: {
-    intro: "Romantic right-bank walks, café culture, and sunset views.",
-    days: [
-      {
-        title: "Day 1 – Louvre to Left Bank",
-        badge: "Art",
-        stops: [
-          "Enter Louvre via Carrousel entrance to skip lines.",
-          "Picnic lunch in Tuileries gardens.",
-          "Cross Pont des Arts toward Saint-Germain jazz bars.",
-        ],
-      },
-      {
-        title: "Day 2 – Montmartre & Seine",
-        badge: "Views",
-        stops: [
-          "Sunrise steps at Sacré-Cœur before crowds.",
-          "Atelier visit along Rue des Martyrs for pastries + art.",
-          "Golden hour cruise on the Seine; upper deck seating.",
-        ],
-      },
-    ],
-    notes: [
-      "Cafés expect you to linger; no rush on seating.",
-      "Metro Line 14 is fastest crosstown route.",
-    ],
-  },
-  Tokyo: {
-    intro: "Design-forward neighborhoods with food stops every block.",
-    days: [
-      {
-        title: "Day 1 – Shibuya & Omotesandō",
-        badge: "Fashion",
-        stops: [
-          "Shibuya Sky for morning cityscape.",
-          "Cat Street indie boutiques and coffee at Omotesandō Koffee.",
-          "Harajuku crepes en route to Meiji Shrine's forest walk.",
-        ],
-      },
-      {
-        title: "Day 2 – Asakusa & Sumida",
-        badge: "Heritage",
-        stops: [
-          "Senso-ji at 7am; photograph Nakamise before shops open.",
-          "Riverside cycle along Sumida with Skytree views.",
-          "Chef's counter ramen at midday to avoid queues.",
-        ],
-      },
-    ],
-    notes: [
-      "Suica/PASMO IC cards work on most trains and kiosks.",
-      "Carry cash for small ramen shops; cards not always accepted.",
-    ],
-  },
-};
-
-let sessionInterval = null;
-let sessionSeconds = 0;
-let activeEmail = "";
-
 const loginForm = document.getElementById("login-form");
 const statusEl = document.getElementById("status");
-const viewer = document.getElementById("viewer");
-const welcomeEl = document.getElementById("welcome");
-const citySelect = document.getElementById("city-select");
-const dayNav = document.getElementById("day-nav");
-const planContent = document.getElementById("plan-content");
-const sessionTimer = document.getElementById("session-timer");
-const overlay = document.getElementById("overlay");
-const watermark = document.getElementById("watermark");
-const reactivateBtn = document.getElementById("reactivate");
-const restartSessionBtn = document.getElementById("restart-session");
-const plan = document.getElementById("plan");
-const cityTitle = document.getElementById("city-title");
+const togglePasswordBtn = document.getElementById("toggle-password");
+const passwordInput = document.getElementById("password");
 
-function formatSeconds(secs) {
-  const m = Math.floor(secs / 60)
-    .toString()
-    .padStart(2, "0");
-  const s = Math.floor(secs % 60)
-    .toString()
-    .padStart(2, "0");
-  return `${m}:${s}`;
+function showStatus(message, type = "info") {
+  statusEl.textContent = message;
+  statusEl.dataset.type = type;
 }
 
-function setWatermark(text) {
-  const svg = `<svg xmlns='http://www.w3.org/2000/svg' width='320' height='200' viewBox='0 0 320 200'>` +
-    `<text x='0' y='30' fill='rgba(12,20,47,0.25)' font-size='18' transform='rotate(-20 60 60)'>${text}</text>` +
-    `</svg>`;
-  const encoded = encodeURIComponent(svg);
-  watermark.style.backgroundImage = `url("data:image/svg+xml,${encoded}")`;
-}
-
-function populateCities() {
-  Object.keys(plans).forEach((city) => {
-    const opt = document.createElement("option");
-    opt.value = city;
-    opt.textContent = city;
-    citySelect.appendChild(opt);
-  });
-}
-
-function renderDayNav(city) {
-  dayNav.innerHTML = "";
-  plans[city].days.forEach((day, index) => {
-    const btn = document.createElement("button");
-    btn.type = "button";
-    btn.textContent = day.title;
-    btn.setAttribute("aria-pressed", index === 0 ? "true" : "false");
-    btn.addEventListener("click", () => {
-      Array.from(dayNav.children).forEach((child) => child.setAttribute("aria-pressed", "false"));
-      btn.setAttribute("aria-pressed", "true");
-      renderPlan(city, index);
-    });
-    const li = document.createElement("li");
-    li.appendChild(btn);
-    dayNav.appendChild(li);
-  });
-}
-
-function renderPlan(city, dayIndex = 0) {
-  const data = plans[city];
-  const day = data.days[dayIndex];
-  cityTitle.textContent = `${city} plan`;
-  planContent.innerHTML = `
-    <div>
-      <span class="badge">${day.badge}</span>
-      <h3>${day.title}</h3>
-      <p>${data.intro}</p>
-      <ul>
-        ${day.stops.map((stop) => `<li>${stop}</li>`).join("")}
-      </ul>
-    </div>
-    <div>
-      <h3>Traveler tips</h3>
-      <ul>
-        ${data.notes.map((note) => `<li>${note}</li>`).join("")}
-      </ul>
-    </div>
-  `;
-}
-
-function startSession() {
-  clearInterval(sessionInterval);
-  sessionSeconds = 5 * 60;
-  sessionTimer.textContent = `Session time: ${formatSeconds(sessionSeconds)} remaining`;
-  overlay.hidden = true;
-  planContent.classList.remove("locked");
-  sessionInterval = setInterval(() => {
-    sessionSeconds -= 1;
-    sessionTimer.textContent = `Session time: ${formatSeconds(Math.max(sessionSeconds, 0))} remaining`;
-    if (sessionSeconds <= 0) {
-      endSession();
-    }
-  }, 1000);
-}
-
-function endSession() {
-  clearInterval(sessionInterval);
-  overlay.hidden = false;
-  planContent.classList.add("locked");
-}
-
-function authenticate(email, password) {
-  const trimmed = email.trim().toLowerCase();
-  if ((trimmed === demoUser.email && password === demoUser.password) || (trimmed && password)) {
-    return { email: trimmed };
+function validateCredentials(email, password) {
+  if (!email || !password) {
+    showStatus("Email and password are required.", "error");
+    return false;
   }
-  return null;
+
+  const normalizedEmail = email.trim().toLowerCase();
+  const isDemo =
+    normalizedEmail === demoCredentials.email && password === demoCredentials.password;
+
+  if (isDemo) {
+    showStatus("Login successful. Opening your plan…", "success");
+    return true;
+  }
+
+  showStatus("Invalid credentials. Try the demo login to preview the experience.", "error");
+  return false;
 }
 
-function displayWelcome(email) {
-  welcomeEl.textContent = `Signed in as ${email}`;
-  setWatermark(`${email} · Every City Plan`);
+function togglePassword() {
+  const currentlyHidden = passwordInput.type === "password";
+  passwordInput.type = currentlyHidden ? "text" : "password";
+  togglePasswordBtn.textContent = currentlyHidden ? "Hide" : "Show";
+  togglePasswordBtn.setAttribute("aria-pressed", String(currentlyHidden));
 }
-
-function disableInteractions() {
-  document.addEventListener("contextmenu", (event) => event.preventDefault());
-  document.addEventListener("copy", (event) => {
-    event.preventDefault();
-    statusEl.textContent = "Copying is disabled in secure view.";
-  });
-  document.addEventListener("keydown", (event) => {
-    const combo = event.ctrlKey || event.metaKey;
-    if (combo && ["s", "p", "c"].includes(event.key.toLowerCase())) {
-      event.preventDefault();
-      statusEl.textContent = "Downloading, printing, and copying are disabled.";
-    }
-  });
-  window.onbeforeprint = () => {
-    return "Printing is disabled for this secure plan.";
-  };
-}
-
-disableInteractions();
-populateCities();
-renderDayNav(citySelect.value || "New York");
-renderPlan(citySelect.value || "New York");
 
 loginForm.addEventListener("submit", (event) => {
   event.preventDefault();
   const email = loginForm.email.value;
   const password = loginForm.password.value;
-  const user = authenticate(email, password);
 
-  if (!user) {
-    statusEl.textContent = "Invalid credentials. Try the demo details.";
-    return;
-  }
+  const isValid = loginForm.reportValidity();
+  if (!isValid) return;
 
-  activeEmail = user.email;
-  statusEl.textContent = "Access granted. Viewer unlocked.";
-  viewer.hidden = false;
-  displayWelcome(user.email);
-  plan.focus({ preventScroll: false });
-  startSession();
+  validateCredentials(email, password);
 });
 
-citySelect.addEventListener("change", () => {
-  const city = citySelect.value;
-  renderDayNav(city);
-  renderPlan(city);
-});
-
-reactivateBtn.addEventListener("click", startSession);
-restartSessionBtn.addEventListener("click", startSession);
+togglePasswordBtn.addEventListener("click", togglePassword);

--- a/script.js
+++ b/script.js
@@ -1,0 +1,262 @@
+const demoUser = {
+  email: "traveler@everycityplan.com",
+  password: "demo123",
+};
+
+const plans = {
+  "New York": {
+    intro: "48 hours of architecture, skyline views, and local eats.",
+    days: [
+      {
+        title: "Day 1 – Midtown Icons",
+        badge: "Skylines",
+        stops: [
+          "Sunrise at Top of the Rock; book timed entry.",
+          "Walk Fifth Avenue to Bryant Park espresso stop.",
+          "Lunch at Urbanspace food hall; rotate cuisines.",
+          "Grand Central whispering gallery and market pick-up.",
+          "Evening show in Broadway's Theater District.",
+        ],
+      },
+      {
+        title: "Day 2 – Downtown Art & Waterfront",
+        badge: "Culture",
+        stops: [
+          "SoHo galleries before 11am for quiet viewing.",
+          "9/11 Memorial; reserve museum ahead.",
+          "Oculus + Brookfield Place for design and dining.",
+          "Sunset walk on the Brooklyn Bridge ending in DUMBO pizza.",
+        ],
+      },
+    ],
+    notes: [
+      "Use the 7-day MetroCard for unlimited subway rides.",
+      "Book observation decks 2 weeks out for best slots.",
+    ],
+  },
+  Paris: {
+    intro: "Romantic right-bank walks, café culture, and sunset views.",
+    days: [
+      {
+        title: "Day 1 – Louvre to Left Bank",
+        badge: "Art",
+        stops: [
+          "Enter Louvre via Carrousel entrance to skip lines.",
+          "Picnic lunch in Tuileries gardens.",
+          "Cross Pont des Arts toward Saint-Germain jazz bars.",
+        ],
+      },
+      {
+        title: "Day 2 – Montmartre & Seine",
+        badge: "Views",
+        stops: [
+          "Sunrise steps at Sacré-Cœur before crowds.",
+          "Atelier visit along Rue des Martyrs for pastries + art.",
+          "Golden hour cruise on the Seine; upper deck seating.",
+        ],
+      },
+    ],
+    notes: [
+      "Cafés expect you to linger; no rush on seating.",
+      "Metro Line 14 is fastest crosstown route.",
+    ],
+  },
+  Tokyo: {
+    intro: "Design-forward neighborhoods with food stops every block.",
+    days: [
+      {
+        title: "Day 1 – Shibuya & Omotesandō",
+        badge: "Fashion",
+        stops: [
+          "Shibuya Sky for morning cityscape.",
+          "Cat Street indie boutiques and coffee at Omotesandō Koffee.",
+          "Harajuku crepes en route to Meiji Shrine's forest walk.",
+        ],
+      },
+      {
+        title: "Day 2 – Asakusa & Sumida",
+        badge: "Heritage",
+        stops: [
+          "Senso-ji at 7am; photograph Nakamise before shops open.",
+          "Riverside cycle along Sumida with Skytree views.",
+          "Chef's counter ramen at midday to avoid queues.",
+        ],
+      },
+    ],
+    notes: [
+      "Suica/PASMO IC cards work on most trains and kiosks.",
+      "Carry cash for small ramen shops; cards not always accepted.",
+    ],
+  },
+};
+
+let sessionInterval = null;
+let sessionSeconds = 0;
+let activeEmail = "";
+
+const loginForm = document.getElementById("login-form");
+const statusEl = document.getElementById("status");
+const viewer = document.getElementById("viewer");
+const welcomeEl = document.getElementById("welcome");
+const citySelect = document.getElementById("city-select");
+const dayNav = document.getElementById("day-nav");
+const planContent = document.getElementById("plan-content");
+const sessionTimer = document.getElementById("session-timer");
+const overlay = document.getElementById("overlay");
+const watermark = document.getElementById("watermark");
+const reactivateBtn = document.getElementById("reactivate");
+const restartSessionBtn = document.getElementById("restart-session");
+const plan = document.getElementById("plan");
+const cityTitle = document.getElementById("city-title");
+
+function formatSeconds(secs) {
+  const m = Math.floor(secs / 60)
+    .toString()
+    .padStart(2, "0");
+  const s = Math.floor(secs % 60)
+    .toString()
+    .padStart(2, "0");
+  return `${m}:${s}`;
+}
+
+function setWatermark(text) {
+  const svg = `<svg xmlns='http://www.w3.org/2000/svg' width='320' height='200' viewBox='0 0 320 200'>` +
+    `<text x='0' y='30' fill='rgba(12,20,47,0.25)' font-size='18' transform='rotate(-20 60 60)'>${text}</text>` +
+    `</svg>`;
+  const encoded = encodeURIComponent(svg);
+  watermark.style.backgroundImage = `url("data:image/svg+xml,${encoded}")`;
+}
+
+function populateCities() {
+  Object.keys(plans).forEach((city) => {
+    const opt = document.createElement("option");
+    opt.value = city;
+    opt.textContent = city;
+    citySelect.appendChild(opt);
+  });
+}
+
+function renderDayNav(city) {
+  dayNav.innerHTML = "";
+  plans[city].days.forEach((day, index) => {
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.textContent = day.title;
+    btn.setAttribute("aria-pressed", index === 0 ? "true" : "false");
+    btn.addEventListener("click", () => {
+      Array.from(dayNav.children).forEach((child) => child.setAttribute("aria-pressed", "false"));
+      btn.setAttribute("aria-pressed", "true");
+      renderPlan(city, index);
+    });
+    const li = document.createElement("li");
+    li.appendChild(btn);
+    dayNav.appendChild(li);
+  });
+}
+
+function renderPlan(city, dayIndex = 0) {
+  const data = plans[city];
+  const day = data.days[dayIndex];
+  cityTitle.textContent = `${city} plan`;
+  planContent.innerHTML = `
+    <div>
+      <span class="badge">${day.badge}</span>
+      <h3>${day.title}</h3>
+      <p>${data.intro}</p>
+      <ul>
+        ${day.stops.map((stop) => `<li>${stop}</li>`).join("")}
+      </ul>
+    </div>
+    <div>
+      <h3>Traveler tips</h3>
+      <ul>
+        ${data.notes.map((note) => `<li>${note}</li>`).join("")}
+      </ul>
+    </div>
+  `;
+}
+
+function startSession() {
+  clearInterval(sessionInterval);
+  sessionSeconds = 5 * 60;
+  sessionTimer.textContent = `Session time: ${formatSeconds(sessionSeconds)} remaining`;
+  overlay.hidden = true;
+  planContent.classList.remove("locked");
+  sessionInterval = setInterval(() => {
+    sessionSeconds -= 1;
+    sessionTimer.textContent = `Session time: ${formatSeconds(Math.max(sessionSeconds, 0))} remaining`;
+    if (sessionSeconds <= 0) {
+      endSession();
+    }
+  }, 1000);
+}
+
+function endSession() {
+  clearInterval(sessionInterval);
+  overlay.hidden = false;
+  planContent.classList.add("locked");
+}
+
+function authenticate(email, password) {
+  const trimmed = email.trim().toLowerCase();
+  if ((trimmed === demoUser.email && password === demoUser.password) || (trimmed && password)) {
+    return { email: trimmed };
+  }
+  return null;
+}
+
+function displayWelcome(email) {
+  welcomeEl.textContent = `Signed in as ${email}`;
+  setWatermark(`${email} · Every City Plan`);
+}
+
+function disableInteractions() {
+  document.addEventListener("contextmenu", (event) => event.preventDefault());
+  document.addEventListener("copy", (event) => {
+    event.preventDefault();
+    statusEl.textContent = "Copying is disabled in secure view.";
+  });
+  document.addEventListener("keydown", (event) => {
+    const combo = event.ctrlKey || event.metaKey;
+    if (combo && ["s", "p", "c"].includes(event.key.toLowerCase())) {
+      event.preventDefault();
+      statusEl.textContent = "Downloading, printing, and copying are disabled.";
+    }
+  });
+  window.onbeforeprint = () => {
+    return "Printing is disabled for this secure plan.";
+  };
+}
+
+disableInteractions();
+populateCities();
+renderDayNav(citySelect.value || "New York");
+renderPlan(citySelect.value || "New York");
+
+loginForm.addEventListener("submit", (event) => {
+  event.preventDefault();
+  const email = loginForm.email.value;
+  const password = loginForm.password.value;
+  const user = authenticate(email, password);
+
+  if (!user) {
+    statusEl.textContent = "Invalid credentials. Try the demo details.";
+    return;
+  }
+
+  activeEmail = user.email;
+  statusEl.textContent = "Access granted. Viewer unlocked.";
+  viewer.hidden = false;
+  displayWelcome(user.email);
+  plan.focus({ preventScroll: false });
+  startSession();
+});
+
+citySelect.addEventListener("change", () => {
+  const city = citySelect.value;
+  renderDayNav(city);
+  renderPlan(city);
+});
+
+reactivateBtn.addEventListener("click", startSession);
+restartSessionBtn.addEventListener("click", startSession);

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,331 @@
+:root {
+  --bg: #0b1021;
+  --card: #121832;
+  --card-strong: #0f1730;
+  --text: #e6ecff;
+  --muted: #a1accb;
+  --accent: #7cf0c4;
+  --accent-strong: #47c3ff;
+  --border: rgba(255, 255, 255, 0.08);
+  --shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
+  --radius: 14px;
+  --nav-width: 280px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", system-ui, -apple-system, sans-serif;
+  background: radial-gradient(circle at 10% 20%, rgba(124, 240, 196, 0.08), transparent 25%),
+    radial-gradient(circle at 80% 10%, rgba(71, 195, 255, 0.12), transparent 25%),
+    radial-gradient(circle at 50% 70%, rgba(124, 240, 196, 0.1), transparent 30%),
+    var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 28px;
+  padding: 64px clamp(18px, 4vw, 60px) 32px;
+  align-items: center;
+}
+
+.hero__content h1 {
+  font-size: clamp(32px, 4vw, 44px);
+  margin: 10px 0 12px;
+}
+
+.hero__content .lede {
+  color: var(--muted);
+  max-width: 720px;
+  line-height: 1.6;
+}
+
+.hero__cta {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.card {
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0.02));
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 24px;
+  box-shadow: var(--shadow);
+}
+
+.card h2,
+.card h3 {
+  margin-top: 0;
+}
+
+.card .muted {
+  margin-top: -6px;
+}
+
+.layout {
+  padding: 0 clamp(18px, 4vw, 60px) 48px;
+}
+
+.form {
+  display: grid;
+  gap: 10px;
+  margin-top: 16px;
+}
+
+.form__label {
+  font-size: 14px;
+  color: var(--muted);
+}
+
+.form__input {
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text);
+  padding: 12px;
+  font-size: 15px;
+}
+
+.form__input:focus {
+  outline: 2px solid rgba(124, 240, 196, 0.6);
+  border-color: transparent;
+}
+
+.form__input--select {
+  min-width: 220px;
+}
+
+.button {
+  appearance: none;
+  border: none;
+  border-radius: 12px;
+  padding: 12px 16px;
+  font-weight: 700;
+  background: linear-gradient(120deg, var(--accent), var(--accent-strong));
+  color: #0b1021;
+  cursor: pointer;
+  transition: transform 150ms ease, box-shadow 150ms ease;
+  box-shadow: 0 10px 40px rgba(124, 240, 196, 0.2);
+}
+
+.button:hover {
+  transform: translateY(-1px);
+}
+
+.button:active {
+  transform: translateY(1px);
+}
+
+.button--ghost {
+  background: transparent;
+  color: var(--text);
+  border: 1px solid var(--border);
+  box-shadow: none;
+}
+
+.helper {
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.status {
+  min-height: 20px;
+  color: var(--accent);
+  margin: 10px 0 0;
+}
+
+.viewer__header {
+  display: flex;
+  gap: 20px;
+  justify-content: space-between;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  margin-bottom: 12px;
+}
+
+.controls {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.viewer__body {
+  display: grid;
+  grid-template-columns: 1fr 2fr;
+  gap: 16px;
+  margin-top: 12px;
+}
+
+.panel {
+  background: var(--card-strong);
+  border-radius: var(--radius);
+  padding: 18px;
+  border: 1px solid var(--border);
+}
+
+.nav {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 14px;
+  display: grid;
+  gap: 8px;
+}
+
+.nav button {
+  width: 100%;
+  text-align: left;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid transparent;
+  color: var(--text);
+  padding: 10px 12px;
+  border-radius: 10px;
+  cursor: pointer;
+  font-weight: 600;
+  transition: background 150ms ease, border-color 150ms ease;
+}
+
+.nav button:hover,
+.nav button[aria-pressed="true"] {
+  background: rgba(124, 240, 196, 0.14);
+  border-color: rgba(124, 240, 196, 0.35);
+}
+
+.callout {
+  background: rgba(124, 240, 196, 0.08);
+  border: 1px solid rgba(124, 240, 196, 0.3);
+  border-radius: 10px;
+  padding: 12px;
+  color: var(--text);
+}
+
+.callout__title {
+  font-weight: 700;
+  margin: 0 0 6px;
+}
+
+.callout__list {
+  margin: 0;
+  padding-left: 18px;
+  color: var(--muted);
+}
+
+.plan {
+  position: relative;
+  background: var(--card);
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  overflow: hidden;
+  min-height: 420px;
+}
+
+.plan__content {
+  padding: 18px;
+  display: grid;
+  gap: 18px;
+  user-select: none;
+}
+
+.plan__content.locked {
+  filter: blur(4px);
+  pointer-events: none;
+}
+
+.plan__content h3 {
+  margin: 0;
+}
+
+.plan__content p,
+.plan__content li {
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.plan__content ul {
+  margin: 6px 0 0;
+  padding-left: 18px;
+}
+
+.badge {
+  display: inline-flex;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: rgba(124, 240, 196, 0.14);
+  color: var(--accent);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  font-size: 12px;
+}
+
+.overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(11, 16, 33, 0.8);
+  display: grid;
+  place-items: center;
+  text-align: center;
+  padding: 20px;
+  backdrop-filter: blur(2px);
+}
+
+.overlay p {
+  max-width: 420px;
+  margin-bottom: 16px;
+}
+
+.footer {
+  text-align: center;
+  color: var(--muted);
+  padding: 32px 18px 40px;
+  font-size: 14px;
+}
+
+.footer a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.eyebrow {
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 800;
+  color: var(--accent);
+  font-size: 12px;
+}
+
+.muted {
+  color: var(--muted);
+}
+
+.watermark {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background-repeat: repeat;
+  opacity: 0.25;
+  mix-blend-mode: multiply;
+}
+
+.plan:focus-within .watermark,
+.plan:hover .watermark {
+  opacity: 0.32;
+}
+
+@media (max-width: 960px) {
+  .viewer__body {
+    grid-template-columns: 1fr;
+  }
+
+  .controls {
+    width: 100%;
+    justify-content: flex-start;
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -1,15 +1,17 @@
 :root {
-  --bg: #0b1021;
-  --card: #121832;
-  --card-strong: #0f1730;
-  --text: #e6ecff;
-  --muted: #a1accb;
-  --accent: #7cf0c4;
-  --accent-strong: #47c3ff;
+  --bg: #0c1328;
+  --surface: rgba(255, 255, 255, 0.05);
   --border: rgba(255, 255, 255, 0.08);
-  --shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
-  --radius: 14px;
-  --nav-width: 280px;
+  --text: #f8fbff;
+  --muted: #a8b5d1;
+  --accent: #6fd1ff;
+  --accent-strong: #9b7bff;
+  --danger: #ff6b6b;
+  --success: #8fe388;
+  --shadow: 0 25px 60px rgba(0, 0, 0, 0.35);
+  --radius: 16px;
+  --radius-sm: 10px;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 
 * {
@@ -18,314 +20,232 @@
 
 body {
   margin: 0;
-  font-family: "Inter", system-ui, -apple-system, sans-serif;
-  background: radial-gradient(circle at 10% 20%, rgba(124, 240, 196, 0.08), transparent 25%),
-    radial-gradient(circle at 80% 10%, rgba(71, 195, 255, 0.12), transparent 25%),
-    radial-gradient(circle at 50% 70%, rgba(124, 240, 196, 0.1), transparent 30%),
+  min-height: 100vh;
+  background: radial-gradient(circle at 15% 20%, rgba(111, 209, 255, 0.15), transparent 25%),
+    radial-gradient(circle at 85% 10%, rgba(155, 123, 255, 0.2), transparent 30%),
+    radial-gradient(circle at 50% 80%, rgba(111, 209, 255, 0.1), transparent 35%),
     var(--bg);
   color: var(--text);
-  min-height: 100vh;
-}
-
-.hero {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-  gap: 28px;
-  padding: 64px clamp(18px, 4vw, 60px) 32px;
-  align-items: center;
-}
-
-.hero__content h1 {
-  font-size: clamp(32px, 4vw, 44px);
-  margin: 10px 0 12px;
-}
-
-.hero__content .lede {
-  color: var(--muted);
-  max-width: 720px;
-  line-height: 1.6;
-}
-
-.hero__cta {
-  display: flex;
-  justify-content: flex-end;
-}
-
-.card {
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0.02));
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 24px;
-  box-shadow: var(--shadow);
-}
-
-.card h2,
-.card h3 {
-  margin-top: 0;
-}
-
-.card .muted {
-  margin-top: -6px;
-}
-
-.layout {
-  padding: 0 clamp(18px, 4vw, 60px) 48px;
-}
-
-.form {
-  display: grid;
-  gap: 10px;
-  margin-top: 16px;
-}
-
-.form__label {
-  font-size: 14px;
-  color: var(--muted);
-}
-
-.form__input {
-  border-radius: 10px;
-  border: 1px solid var(--border);
-  background: rgba(255, 255, 255, 0.04);
-  color: var(--text);
-  padding: 12px;
-  font-size: 15px;
-}
-
-.form__input:focus {
-  outline: 2px solid rgba(124, 240, 196, 0.6);
-  border-color: transparent;
-}
-
-.form__input--select {
-  min-width: 220px;
-}
-
-.button {
-  appearance: none;
-  border: none;
-  border-radius: 12px;
-  padding: 12px 16px;
-  font-weight: 700;
-  background: linear-gradient(120deg, var(--accent), var(--accent-strong));
-  color: #0b1021;
-  cursor: pointer;
-  transition: transform 150ms ease, box-shadow 150ms ease;
-  box-shadow: 0 10px 40px rgba(124, 240, 196, 0.2);
-}
-
-.button:hover {
-  transform: translateY(-1px);
-}
-
-.button:active {
-  transform: translateY(1px);
-}
-
-.button--ghost {
-  background: transparent;
-  color: var(--text);
-  border: 1px solid var(--border);
-  box-shadow: none;
-}
-
-.helper {
-  color: var(--muted);
-  font-size: 13px;
-}
-
-.status {
-  min-height: 20px;
-  color: var(--accent);
-  margin: 10px 0 0;
-}
-
-.viewer__header {
-  display: flex;
-  gap: 20px;
-  justify-content: space-between;
-  align-items: flex-start;
-  flex-wrap: wrap;
-  margin-bottom: 12px;
-}
-
-.controls {
-  display: flex;
-  gap: 12px;
-  align-items: center;
-  flex-wrap: wrap;
-  justify-content: flex-end;
-}
-
-.viewer__body {
-  display: grid;
-  grid-template-columns: 1fr 2fr;
-  gap: 16px;
-  margin-top: 12px;
-}
-
-.panel {
-  background: var(--card-strong);
-  border-radius: var(--radius);
-  padding: 18px;
-  border: 1px solid var(--border);
-}
-
-.nav {
-  list-style: none;
-  padding: 0;
-  margin: 0 0 14px;
-  display: grid;
-  gap: 8px;
-}
-
-.nav button {
-  width: 100%;
-  text-align: left;
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid transparent;
-  color: var(--text);
-  padding: 10px 12px;
-  border-radius: 10px;
-  cursor: pointer;
-  font-weight: 600;
-  transition: background 150ms ease, border-color 150ms ease;
-}
-
-.nav button:hover,
-.nav button[aria-pressed="true"] {
-  background: rgba(124, 240, 196, 0.14);
-  border-color: rgba(124, 240, 196, 0.35);
-}
-
-.callout {
-  background: rgba(124, 240, 196, 0.08);
-  border: 1px solid rgba(124, 240, 196, 0.3);
-  border-radius: 10px;
-  padding: 12px;
-  color: var(--text);
-}
-
-.callout__title {
-  font-weight: 700;
-  margin: 0 0 6px;
-}
-
-.callout__list {
-  margin: 0;
-  padding-left: 18px;
-  color: var(--muted);
-}
-
-.plan {
-  position: relative;
-  background: var(--card);
-  border-radius: var(--radius);
-  border: 1px solid var(--border);
-  overflow: hidden;
-  min-height: 420px;
-}
-
-.plan__content {
-  padding: 18px;
-  display: grid;
-  gap: 18px;
-  user-select: none;
-}
-
-.plan__content.locked {
-  filter: blur(4px);
-  pointer-events: none;
-}
-
-.plan__content h3 {
-  margin: 0;
-}
-
-.plan__content p,
-.plan__content li {
-  color: var(--muted);
-  line-height: 1.6;
-}
-
-.plan__content ul {
-  margin: 6px 0 0;
-  padding-left: 18px;
-}
-
-.badge {
-  display: inline-flex;
-  padding: 6px 10px;
-  border-radius: 999px;
-  background: rgba(124, 240, 196, 0.14);
-  color: var(--accent);
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.03em;
-  font-size: 12px;
-}
-
-.overlay {
-  position: absolute;
-  inset: 0;
-  background: rgba(11, 16, 33, 0.8);
   display: grid;
   place-items: center;
-  text-align: center;
-  padding: 20px;
-  backdrop-filter: blur(2px);
+  padding: 48px 16px 32px;
 }
 
-.overlay p {
-  max-width: 420px;
-  margin-bottom: 16px;
+.page {
+  width: min(1080px, 100%);
+  display: grid;
+  grid-template-columns: 1.1fr 0.9fr;
+  gap: 32px;
+  align-items: start;
 }
 
-.footer {
-  text-align: center;
-  color: var(--muted);
-  padding: 32px 18px 40px;
-  font-size: 14px;
-}
-
-.footer a {
-  color: var(--accent);
-  text-decoration: none;
+.intro {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  padding: 32px;
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(12px);
 }
 
 .eyebrow {
-  letter-spacing: 0.08em;
   text-transform: uppercase;
-  font-weight: 800;
-  color: var(--accent);
+  letter-spacing: 0.08em;
   font-size: 12px;
+  color: var(--accent);
+  margin: 0 0 8px;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: clamp(28px, 4vw, 36px);
+  line-height: 1.2;
+}
+
+h2 {
+  margin: 0;
+  font-size: 22px;
+}
+
+.lede {
+  color: var(--muted);
+  margin: 0 0 16px;
+  font-size: 16px;
+  line-height: 1.5;
+}
+
+.bullets {
+  margin: 0;
+  padding: 0 0 0 18px;
+  color: var(--text);
+  display: grid;
+  gap: 8px;
+  line-height: 1.4;
+}
+
+.panel {
+  background: rgba(255, 255, 255, 0.07);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 28px;
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(10px);
+}
+
+.panel__header {
+  margin-bottom: 16px;
 }
 
 .muted {
   color: var(--muted);
+  margin: 6px 0 0;
 }
 
-.watermark {
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  background-repeat: repeat;
-  opacity: 0.25;
-  mix-blend-mode: multiply;
+.form {
+  display: grid;
+  gap: 14px;
 }
 
-.plan:focus-within .watermark,
-.plan:hover .watermark {
-  opacity: 0.32;
+.form__label {
+  font-weight: 600;
+  font-size: 14px;
+  color: var(--text);
 }
 
-@media (max-width: 960px) {
-  .viewer__body {
+.form__input {
+  width: 100%;
+  padding: 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text);
+  font-size: 15px;
+  outline: none;
+  transition: border 0.2s ease, background 0.2s ease;
+}
+
+.form__input:focus {
+  border-color: var(--accent);
+  background: rgba(111, 209, 255, 0.12);
+}
+
+.form__row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 10px;
+  align-items: end;
+}
+
+.form__row--between {
+  grid-template-columns: auto auto;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.form__field {
+  display: grid;
+  gap: 8px;
+}
+
+.checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.checkbox input {
+  accent-color: var(--accent);
+}
+
+.button {
+  padding: 12px 16px;
+  border-radius: var(--radius-sm);
+  border: none;
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  color: #0c1328;
+  font-weight: 700;
+  cursor: pointer;
+  box-shadow: 0 12px 35px rgba(111, 209, 255, 0.3);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 40px rgba(111, 209, 255, 0.25);
+}
+
+.button:active {
+  transform: translateY(0);
+}
+
+.button--ghost {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text);
+  box-shadow: none;
+  border: 1px solid var(--border);
+}
+
+.helper {
+  margin: 0;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.status {
+  min-height: 20px;
+  font-size: 14px;
+  margin: 4px 0 0;
+  color: var(--text);
+}
+
+.status[data-type="error"] {
+  color: var(--danger);
+}
+
+.status[data-type="success"] {
+  color: var(--success);
+}
+
+.link {
+  color: var(--muted);
+  text-decoration: none;
+  font-size: 14px;
+}
+
+.link[aria-disabled="true"] {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.footer {
+  margin-top: 16px;
+  color: var(--muted);
+  font-size: 14px;
+  text-align: center;
+}
+
+.footer a {
+  color: var(--accent);
+}
+
+@media (max-width: 900px) {
+  body {
+    padding: 32px 16px;
+  }
+
+  .page {
     grid-template-columns: 1fr;
   }
 
-  .controls {
-    width: 100%;
-    justify-content: flex-start;
+  .form__row {
+    grid-template-columns: 1fr;
+  }
+
+  .form__row--between {
+    grid-template-columns: 1fr;
+    gap: 8px;
+    justify-items: start;
   }
 }


### PR DESCRIPTION
## Summary
- add a static secure viewer experience with login gate and session controls
- include sample New York, Paris, and Tokyo plans with navigation and watermarking
- document how to open the prototype and use the demo credentials

## Testing
- Not run (static site)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d7d6bc84483269a5d2277a7f6a670)